### PR TITLE
switched Window.getSelection to return an option since that call might return null

### DIFF
--- a/src/Webapi/Dom/Webapi__Dom__Window.re
+++ b/src/Webapi/Dom/Webapi__Dom__Window.re
@@ -75,7 +75,7 @@ module Impl = (T: {type t;}) => {
   external getComputedStyleWithPseudoElement:
     (t_window, Dom.element, string) => Dom.cssStyleDeclaration =
     "getComputedStyle";
-  [@send] external getSelection: t_window => Dom.selection;
+  [@send] [@return nullable] external getSelection: t_window => option(Dom.selection);
   [@send] external matchMedia: (t_window, string) => mediaQueryList; /* experimental, CSSOM View module */
   [@send] external moveBy: (t_window, int, int) => unit; /* experimental, CSSOM View module */
   [@send] external moveTo: (t_window, int, int) => unit; /* experimental, CSSOM View module */


### PR DESCRIPTION
Relevant specification: https://www.w3.org/TR/selection-api/#webidl-1016100280

window.getSelection might return null it does so on Firefox if you try to get the selection object out of an iframe that is hidden inside a display: none block.