### PR TITLE
Add bindings for WebSocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Done:
 * Converted to rescript syntax (#18)
 * Added `IntersectionObserver` and `IntersectionObserverEntry` bindings (#27)
 * Imported `bs-fetch` and converted it to "t-first" (#31)
+* Added `WebSocket` bindings (#34)
 
 Todo:
 * Convert more input types to `node_like` and `element_like` to improve usability

--- a/examples/webapi_example.res
+++ b/examples/webapi_example.res
@@ -1,0 +1,17 @@
+open Webapi
+
+/* Adapted from https://developer.mozilla.org/en-US/docs/Web/API/WebSocket#examples */
+let _ = {
+  // Create WebSocket connection.
+  let socket = WebSocket.make("ws://localhost:8080")
+
+  // Connection opened
+  socket->WebSocket.addOpenListener(_ => {
+    socket->WebSocket.sendText("Hello Server!")
+  })
+
+  // Listen for messages
+  socket->WebSocket.addMessageListener(event => {
+    Js.log2("Message from server ", event.data)
+  })
+}

--- a/lib/js/examples/webapi_example.js
+++ b/lib/js/examples/webapi_example.js
@@ -1,0 +1,16 @@
+'use strict';
+
+
+var socket = new WebSocket("ws://localhost:8080");
+
+socket.addEventListener("open", (function (param) {
+        socket.send("Hello Server!");
+        
+      }));
+
+socket.addEventListener("message", (function ($$event) {
+        console.log("Message from server ", $$event.data);
+        
+      }));
+
+/* socket Not a pure module */

--- a/src/Webapi.res
+++ b/src/Webapi.res
@@ -16,6 +16,7 @@ module ReadableStream = Webapi__ReadableStream
 module IntersectionObserver = Webapi__IntersectionObserver
 module ResizeObserver = Webapi__ResizeObserver
 module Url = Webapi__Url
+module WebSocket = Webapi__WebSocket
 
 type rafId
 

--- a/src/Webapi/Webapi__WebSocket.res
+++ b/src/Webapi/Webapi__WebSocket.res
@@ -1,0 +1,114 @@
+open Js.TypedArray2
+
+type readyState
+type t<'binaryType> = private {
+  binaryType: [#blob | #arraybuffer],
+  bufferedAmount: float,
+  extensions: string,
+  protocol: string,
+  readyState: readyState,
+  url: string,
+}
+@new external make: string => t<Webapi__Blob.t> = "WebSocket"
+@new external makeArrayBuffer: string => t<array_buffer> = "WebSocket"
+@set external setArrayBuffer: (t<array_buffer>, @as("arraybuffer") _) => unit = "binaryType"
+let makeArrayBuffer = url => {
+  let ws = makeArrayBuffer(url)
+  ws->setArrayBuffer
+  ws
+}
+
+@val @scope("WebSocket") external readyStateClosing: readyState = "CLOSING"
+@val @scope("WebSocket") external readyStateClosed: readyState = "CLOSED"
+@val @scope("WebSocket") external readyStateConnected: readyState = "CONNECTING"
+@val @scope("WebSocket") external readyStateOpen: readyState = "OPEN"
+
+let isOpen = ws => ws.readyState === readyStateOpen
+
+@send external close: t<'binaryType> => unit = "close"
+@send external closeWithReason: (t<'binaryType>, ~code: int, ~reason: string) => unit = "close"
+
+@send
+external addOpenListener: (t<'binaryType>, @as("open") _, Webapi__Dom__Event.t => unit) => unit =
+  "addEventListener"
+@send
+external removeOpenListener: (t<'binaryType>, @as("open") _, Webapi__Dom__Event.t => unit) => unit =
+  "removeEventListener"
+
+type closeEvent = private {
+  code: int,
+  reason: string,
+  wasClean: bool,
+}
+@send
+external addCloseListener: (t<'binaryType>, @as("close") _, closeEvent => unit) => unit =
+  "addEventListener"
+@send
+external removeCloseListener: (t<'binaryType>, @as("close") _, closeEvent => unit) => unit =
+  "removeEventListener"
+
+@send
+external addErrorListener: (t<'binaryType>, @as("error") _, Webapi__Dom__Event.t => unit) => unit =
+  "addEventListener"
+@send
+external removeErrorListener: (
+  t<'binaryType>,
+  @as("error") _,
+  Webapi__Dom__Event.t => unit,
+) => unit = "removeEventListener"
+
+type messageEvent<'binaryType> = {
+  data: Js.Json.t,
+  origin: string,
+  lastEventId: string,
+}
+@send
+external addMessageListener: (
+  t<'binaryType>,
+  @as("message") _,
+  messageEvent<'binaryType> => unit,
+) => unit = "addEventListener"
+@send
+external removeMessageListener: (
+  t<'binaryType>,
+  @as("message") _,
+  messageEvent<'binaryType> => unit,
+) => unit = "removeEventListener"
+
+@send external sendText: (t<'binaryType>, string) => unit = "send"
+@send external sendBlob: (t<'binaryType>, Webapi__Blob.t) => unit = "send"
+@send external sendArrayBuffer: (t<'binaryType>, array_buffer) => unit = "send"
+@send external sendInt8Array: (t<'binaryType>, Int8Array.t) => unit = "send"
+@send external sendInt16Array: (t<'binaryType>, Int16Array.t) => unit = "send"
+@send external sendInt32Array: (t<'binaryType>, Int32Array.t) => unit = "send"
+@send external sendUint8Array: (t<'binaryType>, Uint8Array.t) => unit = "send"
+@send external sendUint8ClampedArray: (t<'binaryType>, Uint8ClampedArray.t) => unit = "send"
+@send external sendUint16Array: (t<'binaryType>, Uint16Array.t) => unit = "send"
+@send external sendUint32Array: (t<'binaryType>, Uint32Array.t) => unit = "send"
+@send external sendFloat32Array: (t<'binaryType>, Float32Array.t) => unit = "send"
+@send external sendFloat64Array: (t<'binaryType>, Float64Array.t) => unit = "send"
+@send external sendDataView: (t<'binaryType>, DataView.t) => unit = "send"
+
+// the data type for binary messages - blob or arraybuffer - is determined by the `binaryType` property set in `make()`.
+@get external unsafeMessageAsBinary: messageEvent<'binaryType> => 'binaryType = "data"
+@get external unsafeMessageAsText: messageEvent<'binaryType> => string = "data"
+let messageIsText = message => {
+  open Js.Types
+  test(message.data, String)
+}
+
+let messageAsText = message => {
+  if message->messageIsText {
+    Some(message->unsafeMessageAsText)
+  } else {
+    None
+  }
+}
+
+let messageAsBinary = message => {
+  if !(message->messageIsText) {
+    Some(message->unsafeMessageAsBinary)
+  } else {
+    None
+  }
+}

--- a/src/Webapi/Webapi__WebSocket.resi
+++ b/src/Webapi/Webapi__WebSocket.resi
@@ -1,0 +1,91 @@
+open Js.TypedArray2
+
+type readyState
+type t<'binaryType> = private {
+  binaryType: [#blob | #arraybuffer],
+  bufferedAmount: float,
+  extensions: string,
+  protocol: string,
+  readyState: readyState,
+  url: string,
+}
+@new external make: string => t<Webapi__Blob.t> = "WebSocket"
+let makeArrayBuffer: string => t<array_buffer>
+
+@val @scope("WebSocket") external readyStateClosing: readyState = "CLOSING"
+@val @scope("WebSocket") external readyStateClosed: readyState = "CLOSED"
+@val @scope("WebSocket") external readyStateConnected: readyState = "CONNECTING"
+@val @scope("WebSocket") external readyStateOpen: readyState = "OPEN"
+
+let isOpen: t<'binaryType> => bool
+
+@send external close: t<'binaryType> => unit = "close"
+@send external closeWithReason: (t<'binaryType>, ~code: int, ~reason: string) => unit = "close"
+
+@send
+external addOpenListener: (t<'binaryType>, @as("open") _, Webapi__Dom__Event.t => unit) => unit =
+  "addEventListener"
+@send
+external removeOpenListener: (t<'binaryType>, @as("open") _, Webapi__Dom__Event.t => unit) => unit =
+  "removeEventListener"
+
+type closeEvent = private {
+  code: int,
+  reason: string,
+  wasClean: bool,
+}
+@send
+external addCloseListener: (t<'binaryType>, @as("close") _, closeEvent => unit) => unit =
+  "addEventListener"
+@send
+external removeCloseListener: (t<'binaryType>, @as("close") _, closeEvent => unit) => unit =
+  "removeEventListener"
+
+@send
+external addErrorListener: (t<'binaryType>, @as("error") _, Webapi__Dom__Event.t => unit) => unit =
+  "addEventListener"
+@send
+external removeErrorListener: (
+  t<'binaryType>,
+  @as("error") _,
+  Webapi__Dom__Event.t => unit,
+) => unit = "removeEventListener"
+
+type messageEvent<'binaryType> = {
+  data: Js.Json.t,
+  origin: string,
+  lastEventId: string,
+}
+@send
+external addMessageListener: (
+  t<'binaryType>,
+  @as("message") _,
+  messageEvent<'binaryType> => unit,
+) => unit = "addEventListener"
+@send
+external removeMessageListener: (
+  t<'binaryType>,
+  @as("message") _,
+  messageEvent<'binaryType> => unit,
+) => unit = "removeEventListener"
+
+@send external sendText: (t<'binaryType>, string) => unit = "send"
+@send external sendBlob: (t<'binaryType>, Webapi__Blob.t) => unit = "send"
+@send external sendArrayBuffer: (t<'binaryType>, array_buffer) => unit = "send"
+@send external sendInt8Array: (t<'binaryType>, Int8Array.t) => unit = "send"
+@send external sendInt16Array: (t<'binaryType>, Int16Array.t) => unit = "send"
+@send external sendInt32Array: (t<'binaryType>, Int32Array.t) => unit = "send"
+@send external sendUint8Array: (t<'binaryType>, Uint8Array.t) => unit = "send"
+@send external sendUint8ClampedArray: (t<'binaryType>, Uint8ClampedArray.t) => unit = "send"
+@send external sendUint16Array: (t<'binaryType>, Uint16Array.t) => unit = "send"
+@send external sendUint32Array: (t<'binaryType>, Uint32Array.t) => unit = "send"
+@send external sendFloat32Array: (t<'binaryType>, Float32Array.t) => unit = "send"
+@send external sendFloat64Array: (t<'binaryType>, Float64Array.t) => unit = "send"
+@send external sendDataView: (t<'binaryType>, DataView.t) => unit = "send"
+
+@get external unsafeMessageAsBinary: messageEvent<'binaryType> => 'binaryType = "data"
+@get external unsafeMessageAsText: messageEvent<'binaryType> => string = "data"
+
+let messageIsText: messageEvent<'binaryType> => bool
+let messageAsText: messageEvent<'binaryType> => option<string>
+let messageAsBinary: messageEvent<'binaryType> => option<'binaryType>


### PR DESCRIPTION
Fixes #4 

Should cover most of the basics, and even a few of the details:

- Creating a WebSocket determines the type of binary messages that are received (blob or array buffer)
- Individual `send` bindings for each type of data supported