### PR TITLE
Add missing APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@
 * Updated `Window.getSelection` api to return an option (#15)
 * Updated `Document.elementFromPoint` api to return an option and be @nullable (#35)
 
-### Added
-* `scrollToWithOptions` method to `window` (#26)
-* `IntersectionObserver` and `IntersectionObserverEntry` bindings (#27)
+### Added and Updated (non-breaking)
 * `WebSocket` bindings (#34)
-* Added `Canvas2d.newPath2D()` to bind `Path2D` objects (#45)
+* `Canvas2d.newPath2D()` to bind `Path2D` objects (#45)
+* `IntersectionObserver` and `IntersectionObserverEntry` bindings (#27)
+* `scrollToWithOptions` method to `window` (#26)
+* `HtmlDocument` methods `hasFocus` and `activeElement` moved to `Document` (#41)
+  * They're still available on `HtmlDocument` thanks to the `include` structure
 
 ### Miscellaneous
 * Converted project to rescript syntax (#18)

--- a/lib/js/tests/Webapi/Dom/Webapi__Dom__Document__test.js
+++ b/lib/js/tests/Webapi/Dom/Webapi__Dom__Document__test.js
@@ -6,6 +6,12 @@ var Webapi__Dom__NodeFilter = require("../../../src/Webapi/Dom/Webapi__Dom__Node
 
 var el = document.createElement("strong");
 
+var e = document.activeElement;
+
+if (!(e == null)) {
+  console.log(e);
+}
+
 Webapi__Dom__Document.compatMode(document);
 
 document.selectedStyleSheetSet = "muh-stylesheet";
@@ -83,6 +89,8 @@ document.getElementsByClassName("lstlisting");
 document.getElementsByTagName("code");
 
 document.getElementsByTagNameNS("http://...", "foo");
+
+document.hasFocus();
 
 document.importNode(el);
 

--- a/lib/js/tests/Webapi/Dom/Webapi__Dom__HtmlDocument__test.js
+++ b/lib/js/tests/Webapi/Dom/Webapi__Dom__HtmlDocument__test.js
@@ -8,6 +8,12 @@ var el = document.createElement("strong");
 
 var htmlDocument = TestHelpers.unsafelyUnwrapOption(Webapi__Dom__Document.asHtmlDocument(document));
 
+var e = htmlDocument.activeElement;
+
+if (!(e == null)) {
+  console.log(e);
+}
+
 htmlDocument.body = el;
 
 htmlDocument.cookie = "foo=bar;reason=ml";

--- a/src/Webapi/Dom/Webapi__Dom__Document.res
+++ b/src/Webapi/Dom/Webapi__Dom__Document.res
@@ -25,6 +25,7 @@ module Impl = (
   let ofNode = (node: Dom.node): option<T.t> =>
     Webapi__Dom__Node.nodeType(node) == Webapi__Dom__Types.Document ? Some(Obj.magic(node)) : None
 
+  @get @return(nullable) external activeElement: T.t => option<Dom.element> = "activeElement"
   @get external characterSet: T.t => string = "characterSet"
   @get external compatMode: T.t => string = "compatMode" /* experimental */
   let compatMode: T.t => Webapi__Dom__Types.compatMode = self =>
@@ -103,6 +104,7 @@ module Impl = (
   @send external getElementsByClassName: (T.t, string) => Dom.htmlCollection = "getElementsByClassName"
   @send external getElementsByTagName: (T.t, string) => Dom.htmlCollection = "getElementsByTagName"
   @send external getElementsByTagNameNS: (T.t, string, string) => Dom.htmlCollection = "getElementsByTagNameNS"
+  @send external hasFocus: T.t => bool = "hasFocus"
   @send external importNode: (T.t, Dom.element_like<'a>) => Dom.element_like<'a> = "importNode"
   @send
   external importNodeDeep: (T.t, Dom.element_like<'a>, @as(json`true`) _) => Dom.element_like<'a> =

--- a/src/Webapi/Dom/Webapi__Dom__HtmlDocument.res
+++ b/src/Webapi/Dom/Webapi__Dom__HtmlDocument.res
@@ -5,7 +5,6 @@ module Impl = (
 ) => {
   type t_htmlDocument = T.t
 
-  @get @return(nullable) external activeElement: t_htmlDocument => option<Dom.element> = "activeElement"
   @get @return(nullable)
   external body: t_htmlDocument => option<Dom.element> = "body" /* returns option HTMLBodyElement */
   @set
@@ -56,7 +55,6 @@ module Impl = (
   ) => self->execCommand(command, show, Js.Null.fromOption(value))
   @send external getElementsByName: (t_htmlDocument, string) => Dom.nodeList = "getElementsByName"
   @send external getSelection: t_htmlDocument => Dom.selection = "getSelection"
-  @send external hasFocus: t_htmlDocument => bool = "hasFocus"
   @send external open_: t_htmlDocument => unit = "open"
   @send external queryCommandEnabled: (t_htmlDocument, string) => bool = "queryCommandEnabled"
   @send external queryCommandIndeterm: (t_htmlDocument, string) => bool = "queryCommandIndeterm"

--- a/tests/Webapi/Dom/Webapi__Dom__Document__test.res
+++ b/tests/Webapi/Dom/Webapi__Dom__Document__test.res
@@ -3,6 +3,11 @@ open Document
 
 let el = document->createElement("strong")
 
+let _ = switch (document->activeElement) {
+  | Some(e) => Js.log(e)
+  | None => ()
+}
+
 let _ = document->characterSet
 let _ = document->compatMode
 let _ = document->doctype
@@ -72,6 +77,7 @@ let _ = document->getAnimations
 let _ = document->getElementsByClassName("lstlisting")
 let _ = document->getElementsByTagName("code")
 let _ = document->getElementsByTagNameNS("http://...", "foo")
+let _ = document->hasFocus
 let _ = document->importNode(el)
 let _ = document->importNodeDeep(el)
 /* TODO: These get dead code eliminated

--- a/tests/Webapi/Dom/Webapi__Dom__HtmlDocument__test.res
+++ b/tests/Webapi/Dom/Webapi__Dom__HtmlDocument__test.res
@@ -4,7 +4,11 @@ open! HtmlDocument
 let el = document->Document.createElement("strong")
 let htmlDocument = document->Document.asHtmlDocument->TestHelpers.unsafelyUnwrapOption
 
-let _ = htmlDocument->activeElement
+let _ = switch (htmlDocument->activeElement) {
+  | Some(e) => Js.log(e)
+  | None => ()
+}
+
 let _ = htmlDocument->body
 let _ = htmlDocument->setBody(el)
 let _ = htmlDocument->cookie


### PR DESCRIPTION
Depends on #40 because it's going to cause conflicts and I don't want to wait until that merges to open this PR. I'll change the target branch here after it merges.

These are the primary remaining methods from our internal 'bs-webapi contrib' layer. There are still a few added modules I haven't ported but we can deal with those later (after 1.0 if I don't get time sooner).

With this, we should be able to switch to `include Webapi.Dom` instead of importing every module individually.

* ~Added `setActiveElement` to Document~ this was incorrect
* Moved `hasFocus` and `activeElement` from HtmlDocument to Document