### PR TITLE
Corrected MutationRecord API

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+insert_final_newline = false
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+end_of_line = lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 * Updated `Window.getSelection` api to return an option (#15)
 * Updated `Document.elementFromPoint` api to return an option and be @nullable (#35)
 * Updated `getClientRects` method on `Document` and `Range` to return a `Dom.RectList.t` (#36)
-* Removed `preview` from File bindings couldn't find it in any specifications. (#56)
+* Removed `preview` from File bindings. It doesn't seem to be in any specifications. (#56)
+* Updated some methods in `MutationRecord` to return nullable values (#59)
+* Corrected spelling of `nextSibling` in `MutationRecord` (#59)
 
 ### Added and Updated (non-breaking)
 * `WebSocket` bindings (#34)

--- a/lib/js/tests/Webapi/Dom/Webapi__Dom__MutationObserver__test.js
+++ b/lib/js/tests/Webapi/Dom/Webapi__Dom__MutationObserver__test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+var Caml_option = require("rescript/lib/js/caml_option.js");
+
+var el = document.createElement("strong");
+
+var observer = new MutationObserver((function (_records, _observer) {
+        
+      }));
+
+observer.observe(el, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeOldValue: true,
+      characterData: true,
+      characterDataOldValue: true
+    });
+
+observer.disconnect();
+
+var records = observer.takeRecords();
+
+var aRecord = records[0];
+
+var recordType = aRecord.type;
+
+var recordTarget = aRecord.target;
+
+var recordAddedNodes = aRecord.addedNodes;
+
+var recordRemovedNodes = aRecord.removedNodes;
+
+var recordPrevSibling = aRecord.previousSibling;
+
+var recordNextSibling = aRecord.nextSibling;
+
+var recordAttributeName = aRecord.attributeName;
+
+var recordAttributeNamespace = aRecord.attributeNamespace;
+
+var recordOldValue = aRecord.oldValue;
+
+var recordPrevSibling$1 = (recordPrevSibling == null) ? undefined : Caml_option.some(recordPrevSibling);
+
+var recordNextSibling$1 = (recordNextSibling == null) ? undefined : Caml_option.some(recordNextSibling);
+
+var recordAttributeName$1 = (recordAttributeName == null) ? undefined : Caml_option.some(recordAttributeName);
+
+var recordAttributeNamespace$1 = (recordAttributeNamespace == null) ? undefined : Caml_option.some(recordAttributeNamespace);
+
+var recordOldValue$1 = (recordOldValue == null) ? undefined : Caml_option.some(recordOldValue);
+
+exports.el = el;
+exports.observer = observer;
+exports.records = records;
+exports.aRecord = aRecord;
+exports.recordType = recordType;
+exports.recordTarget = recordTarget;
+exports.recordAddedNodes = recordAddedNodes;
+exports.recordRemovedNodes = recordRemovedNodes;
+exports.recordPrevSibling = recordPrevSibling$1;
+exports.recordNextSibling = recordNextSibling$1;
+exports.recordAttributeName = recordAttributeName$1;
+exports.recordAttributeNamespace = recordAttributeNamespace$1;
+exports.recordOldValue = recordOldValue$1;
+/* el Not a pure module */

--- a/src/Webapi/Dom/Webapi__Dom__MutationRecord.res
+++ b/src/Webapi/Dom/Webapi__Dom__MutationRecord.res
@@ -1,11 +1,16 @@
+// https://dom.spec.whatwg.org/#interface-mutationrecord
 type t = Dom.mutationRecord
 
 @get external type_: t => string = "type"
 @get external target: t => Dom.node = "target"
 @get external addedNodes: t => Dom.nodeList = "addedNodes"
 @get external removedNodes: t => Dom.nodeList = "removedNodes"
+
+// everything else might return null
 @get @return(nullable) external previousSibling: t => option<Dom.node> = "previousSibling"
-@get @return(nullable) external pnextSibling: t => option<Dom.node> = "pnextSibling"
-@get external attributeName: t => string = "attributeName"
-@get external attributeNamespace: t => string = "attributeNamespace"
-@get external oldValue: t => string = "oldValue"
+@get @return(nullable)
+external nextSibling: t => option<Dom.node> = "nextSibling"
+@get @return(nullable)
+external attributeName: t => option<string> = "attributeName"
+@get @return(nullable) external attributeNamespace: t => option<string> = "attributeNamespace"
+@get @return(nullable) external oldValue: t => option<string> = "oldValue"

--- a/tests/Webapi/Dom/Webapi__Dom__MutationObserver__test.res
+++ b/tests/Webapi/Dom/Webapi__Dom__MutationObserver__test.res
@@ -4,14 +4,17 @@ open MutationObserver
 let el = document->Document.createElement("strong")
 let observer: t = MutationObserver.make((_records, _observer) => ())
 
-let _ = observer->MutationObserver.observe(el, {
-  "subtree": true,
-  "childList": true,
-  "attributes": true,
-  "attributeOldValue": true,
-  "characterData": true,
-  "characterDataOldValue": true,
-})
+let _ = observer->MutationObserver.observe(
+  el,
+  {
+    "subtree": true,
+    "childList": true,
+    "attributes": true,
+    "attributeOldValue": true,
+    "characterData": true,
+    "characterDataOldValue": true,
+  },
+)
 
 let _ = observer->MutationObserver.disconnect
 let records: array<Dom.mutationRecord> = observer->MutationObserver.takeRecords

--- a/tests/Webapi/Dom/Webapi__Dom__MutationObserver__test.res
+++ b/tests/Webapi/Dom/Webapi__Dom__MutationObserver__test.res
@@ -1,0 +1,31 @@
+open Webapi.Dom
+open MutationObserver
+
+let el = document->Document.createElement("strong")
+let observer: t = MutationObserver.make((_records, _observer) => ())
+
+let _ = observer->MutationObserver.observe(el, {
+  "subtree": true,
+  "childList": true,
+  "attributes": true,
+  "attributeOldValue": true,
+  "characterData": true,
+  "characterDataOldValue": true,
+})
+
+let _ = observer->MutationObserver.disconnect
+let records: array<Dom.mutationRecord> = observer->MutationObserver.takeRecords
+let aRecord = records->Js.Array2.unsafe_get(0)
+
+open MutationRecord
+
+let recordType: string = aRecord->type_
+let recordTarget: Dom.node = aRecord->target
+let recordAddedNodes: Dom.nodeList = aRecord->addedNodes
+let recordRemovedNodes: Dom.nodeList = aRecord->removedNodes
+
+let recordPrevSibling: option<Dom.node> = aRecord->previousSibling
+let recordNextSibling: option<Dom.node> = aRecord->nextSibling
+let recordAttributeName: option<string> = aRecord->attributeName
+let recordAttributeNamespace: option<string> = aRecord->attributeNamespace
+let recordOldValue: option<string> = aRecord->oldValue


### PR DESCRIPTION
There was actually a lot more wrong than #54 suggested, looking at the spec! I also added a test.

* Corrected nullable return in `MutationRecord`
* Corrected spelling of `nextSibling`

Fixes #54