### PR TITLE
Change fetch `method` to a string

### DIFF
--- a/examples/fetch_examples.res
+++ b/examples/fetch_examples.res
@@ -8,7 +8,7 @@ let _ = {
 }
 
 let _ = {
-  Fetch.fetchWithInit("/api/hello", Fetch.RequestInit.make(~method_=Post, ()))
+  Fetch.fetchWithInit("/api/hello", Fetch.RequestInit.make(~method="POST", ()))
   ->then(Fetch.Response.text)
   ->then(text => print_endline(text)->resolve)
 }
@@ -31,7 +31,7 @@ let _ = {
   Fetch.fetchWithInit(
     "/api/hello",
     Fetch.RequestInit.make(
-      ~method_=Post,
+      ~method="POST",
       ~body=Fetch.BodyInit.make(Js.Json.stringify(Js.Json.object_(payload))),
       ~headers=Fetch.HeadersInit.make({"Content-Type": "application/json"}),
       (),
@@ -51,7 +51,7 @@ let _ = {
   Fetch.fetchWithInit(
     "/api/upload",
     Fetch.RequestInit.make(
-      ~method_=Post,
+      ~method="POST",
       ~body=Fetch.BodyInit.makeWithFormData(formData),
       ~headers=Fetch.HeadersInit.make({"Accept": "*"}),
       (),

--- a/lib/js/examples/fetch_examples.js
+++ b/lib/js/examples/fetch_examples.js
@@ -11,7 +11,7 @@ fetch("/api/hellos/1").then(function (prim) {
       return Promise.resolve((console.log(text), undefined));
     });
 
-fetch("/api/hello", Webapi__Fetch.RequestInit.make(/* Post */2, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined)(undefined)).then(function (prim) {
+fetch("/api/hello", Webapi__Fetch.RequestInit.make("POST", undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined)(undefined)).then(function (prim) {
         return prim.text();
       }).then(function (text) {
       return Promise.resolve((console.log(text), undefined));
@@ -33,7 +33,7 @@ var payload = {};
 
 payload["hello"] = "world";
 
-fetch("/api/hello", Webapi__Fetch.RequestInit.make(/* Post */2, {
+fetch("/api/hello", Webapi__Fetch.RequestInit.make("POST", {
               "Content-Type": "application/json"
             }, Caml_option.some(JSON.stringify(payload)), undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined)(undefined)).then(function (prim) {
       return prim.json();
@@ -47,7 +47,7 @@ formData.append("image0", {
       name: "image0.jpg"
     }, undefined);
 
-fetch("/api/upload", Webapi__Fetch.RequestInit.make(/* Post */2, {
+fetch("/api/upload", Webapi__Fetch.RequestInit.make("POST", {
               Accept: "*"
             }, Caml_option.some(formData), undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined)(undefined)).then(function (prim) {
       return prim.json();

--- a/src/Webapi/Webapi__Fetch.res
+++ b/src/Webapi/Webapi__Fetch.res
@@ -22,47 +22,6 @@ type urlSearchParams /* URL */
 type blob = Webapi__Blob.t
 type file = Webapi__File.t
 
-type requestMethod =
-  | Get
-  | Head
-  | Post
-  | Put
-  | Delete
-  | Connect
-  | Options
-  | Trace
-  | Patch
-  | Other(string)
-let encodeRequestMethod = x =>
-  /* internal */
-
-  switch x {
-  | Get => "GET"
-  | Head => "HEAD"
-  | Post => "POST"
-  | Put => "PUT"
-  | Delete => "DELETE"
-  | Connect => "CONNECT"
-  | Options => "OPTIONS"
-  | Trace => "TRACE"
-  | Patch => "PATCH"
-  | Other(method_) => method_
-  }
-let decodeRequestMethod = x =>
-  /* internal */
-
-  switch x {
-  | "GET" => Get
-  | "HEAD" => Head
-  | "POST" => Post
-  | "PUT" => Put
-  | "DELETE" => Delete
-  | "CONNECT" => Connect
-  | "OPTIONS" => Options
-  | "TRACE" => Trace
-  | "PATCH" => Patch
-  | method_ => Other(method_)
-  }
 
 type referrerPolicy =
   | None
@@ -332,7 +291,7 @@ module RequestInit = {
 
   @obj
   external make: (
-    ~_method: string=?,
+    ~method: string=?,
     ~headers: headersInit=?,
     ~body: bodyInit=?,
     ~referrer: string=?,
@@ -347,7 +306,7 @@ module RequestInit = {
     unit,
   ) => requestInit = ""
   let make = (
-    ~method_: option<requestMethod>=?,
+    ~method: option<string>=?,
     ~headers: option<headersInit>=?,
     ~body: option<bodyInit>=?,
     ~referrer: option<string>=?,
@@ -361,7 +320,7 @@ module RequestInit = {
     ~signal: option<signal>=?,
   ) =>
     make(
-      ~_method=?map(encodeRequestMethod, method_),
+      ~method?,
       ~headers?,
       ~body?,
       ~referrer?,
@@ -388,8 +347,7 @@ module Request = {
   @new external makeWithRequest: t => t = "Request"
   @new external makeWithRequestInit: (t, requestInit) => t = "Request"
 
-  @get external method_: t => string = "method"
-  let method_: t => requestMethod = self => decodeRequestMethod(method_(self))
+  @get external method: t => string = "method"
   @get external url: t => string = "url"
   @get external headers: t => headers = "headers"
   @get external type_: t => string = "type"

--- a/src/Webapi/Webapi__Fetch.resi
+++ b/src/Webapi/Webapi__Fetch.resi
@@ -24,17 +24,6 @@ type signal = AbortController.signal
 type blob
 type file
 
-type requestMethod =
-  | Get
-  | Head
-  | Post
-  | Put
-  | Delete
-  | Connect
-  | Options
-  | Trace
-  | Patch
-  | Other(string)
 
 type referrerPolicy =
   | None
@@ -151,7 +140,7 @@ module RequestInit: {
   type t = requestInit
 
   let make: (
-    ~method_: requestMethod=?,
+    ~method: string=?,
     ~headers: headersInit=?,
     ~body: bodyInit=?,
     ~referrer: string=?,
@@ -175,7 +164,7 @@ module Request: {
   @new external makeWithRequest: t => t = "Request"
   @new external makeWithRequestInit: (t, requestInit) => t = "Request"
 
-  let method_: t => requestMethod
+  @get external method: t => string = "method"
   @get external url: t => string = "url"
   @get external headers: t => headers = "headers"
   let type_: t => requestType


### PR DESCRIPTION
The variant here wasn't gaining any extra type safety and introducing a cost to the bindings where none was needed.

`method` accepts any arbitrary string and while it's true that some HTTP methods are specced to be in uppercase, the fetch API will [normalise them for you](https://fetch.spec.whatwg.org/#concept-method-normalize).