### PR TITLE
Remove Request requestType

### DIFF
--- a/src/Webapi/Webapi__Fetch.res
+++ b/src/Webapi/Webapi__Fetch.res
@@ -104,30 +104,6 @@ let decodeReferrerPolicy = x =>
   | e => raise(Failure("Unknown referrerPolicy: " ++ e))
   }
 
-type requestType =
-  | None /* default? unknown? just empty string in spec */
-  | Audio
-  | Font
-  | Image
-  | Script
-  | Style
-  | Track
-  | Video
-let decodeRequestType = x =>
-  /* internal */
-
-  switch x {
-  | "audio" => Audio
-  | "" => None
-  | "font" => Font
-  | "image" => Image
-  | "script" => Script
-  | "style" => Style
-  | "track" => Track
-  | "video" => Video
-  | e => raise(Failure("Unknown requestType: " ++ e))
-  }
-
 type requestDestination =
   | None /* default? unknown? just empty string in spec */
   | Document
@@ -392,8 +368,6 @@ module Request = {
   let method_: t => requestMethod = self => decodeRequestMethod(method_(self))
   @get external url: t => string = "url"
   @get external headers: t => headers = "headers"
-  @get external type_: t => string = "type"
-  let type_: t => requestType = self => decodeRequestType(type_(self))
   @get external destination: t => string = "destination"
   let destination: t => requestDestination = self => decodeRequestDestination(destination(self))
   @get external referrer: t => string = "referrer"

--- a/src/Webapi/Webapi__Fetch.resi
+++ b/src/Webapi/Webapi__Fetch.resi
@@ -47,16 +47,6 @@ type referrerPolicy =
   | StrictOriginWhenCrossOrigin
   | UnsafeUrl
 
-type requestType =
-  | None /* default? unknown? just empty string in spec */
-  | Audio
-  | Font
-  | Image
-  | Script
-  | Style
-  | Track
-  | Video
-
 type requestDestination =
   | None /* default? unknown? just empty string in spec */
   | Document
@@ -178,7 +168,6 @@ module Request: {
   let method_: t => requestMethod
   @get external url: t => string = "url"
   @get external headers: t => headers = "headers"
-  let type_: t => requestType
   let destination: t => requestDestination
   @get external referrer: t => string = "referrer"
   let referrerPolicy: t => referrerPolicy


### PR DESCRIPTION
Relates to #30 

As far as I can see this property does not exist in the spec, I assume it was superseded by `destination` but I don't have the context to know for sure.