### PR TITLE
add bidnings to TextEncoder/TextDecoder

### DIFF
--- a/src/Webapi/Webapi__TextDecoder.res
+++ b/src/Webapi/Webapi__TextDecoder.res
@@ -1,0 +1,37 @@
+type t
+
+type decoderOptions
+
+type decodeOptions
+
+%%private(
+  @new external _makeWithOptions: (string, decoderOptions) => t = "TextDecoder"
+
+  @obj
+  external makeDecoderOptions: (
+    ~fatal: option<bool>=?,
+    ~ignoreBOM: option<bool>=?,
+    unit,
+  ) => decoderOptions = ""
+)
+
+@new external make: unit => t = "TextDecoder"
+
+let makeWithOptions = (~encoding="utf-8", ~fatal=?, ~ignoreBOM=?, ()) =>
+  _makeWithOptions(encoding, makeDecoderOptions(~fatal, ~ignoreBOM, ()))
+
+%%private(
+  @obj external makeDecodeOptions: (~stream: bool) => decodeOptions = ""
+
+  @send external _decodeWithOptions: (t, Js.TypedArray2.Uint8Array.t, decodeOptions) => t = "decode"
+)
+
+@send external decode: (t, Js.TypedArray2.Uint8Array.t) => string = "decode"
+
+let decodeStream = (t, array) => _decodeWithOptions(t, array, makeDecodeOptions(~stream=true))
+
+@get external encoding: t => string = "encoding"
+
+@get external fatal: t => bool = "fatal"
+
+@get external ignoreBOM: t => bool = "ignoreBOM"

--- a/src/Webapi/Webapi__TextEncoder.res
+++ b/src/Webapi/Webapi__TextEncoder.res
@@ -1,0 +1,16 @@
+type t
+
+@new external make: unit => t = "TextEncoder"
+
+@send external encode: (t, string) => Js.TypedArray2.Uint8Array.t = "encode"
+
+type encodeIntoResult = {
+  read: int,
+  written: int,
+}
+
+@send
+external encodeInto: (t, string, Js.TypedArray2.Uint8Array.t) => encodeIntoResult = "encodeInto"
+
+// This always returns "utf-8"
+@get external encoding: t => string = "encoding"


### PR DESCRIPTION
- [TextEncoder](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder)
- [TextDecoder](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder)

Both are available on browsers, Node.js, and Deno.

In most cases, it is used without arguments

```res
// UTF-8 encoding/decoding

let e = TextEncoder.make()

e->TextEncoder.encoding // "utf-8"
let bin = e->TextEncoder.encode("Hello, World!")

let d = TextDecoder.make()
d->TextDecoder.decode(bin) // "Hello, World!"
```

I added some additional bindings to support the [full specification](https://encoding.spec.whatwg.org/#api).