### PR TITLE
Add rescript-promise as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   ],
   "author": "Tiny Technologies Inc",
   "license": "MIT",
+  "peerDependencies": {
+    "@ryyppy/rescript-promise": "^2.1.0"
+  },
   "devDependencies": {
     "@ryyppy/rescript-promise": "^2.1.0",
     "rescript": "^9.1.4"


### PR DESCRIPTION
This will ensure that users receive a warning (or error in newer npm versions) when they try to install `rescript-webapi` without also installing `@ryyppy/rescript-promise`.

This should also go into install instructions but I see the documentation hasn't been updated yet, so this can be done in a seperate PR.
