### PR TITLE
Swap history scroll restoration to use 'auto' and 'manual'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Updated `Document.elementFromPoint` binding to return a nullable value (#35)
 * Updated `MutationRecord` bindings `nextSibling`, `attributeName`, `attributeNamespace` and `oldValue` to return nullable values (#59)
 * Corrected spelling of `nextSibling` in `MutationRecord` (#59)
+* Updated `History.scrollRestoration` to use `auto` and `manual` instead of a boolean (#88)
+* `PopStateEvent.state` now returns a history state type instead of an open object (#88)
 
 ### Added (non-breaking)
 * `WebSocket` bindings (#34)

--- a/lib/js/tests/Webapi/Dom/Webapi__Dom__History__test.js
+++ b/lib/js/tests/Webapi/Dom/Webapi__Dom__History__test.js
@@ -1,7 +1,17 @@
 'use strict';
 
 
-window.history.scrollRestoration = true;
+window.history.scrollRestoration = "auto";
+
+window.history.scrollRestoration = "manual";
+
+var match = window.history.scrollRestoration;
+
+if (match === "manual") {
+  console.log("manual scroll");
+} else {
+  console.log("auto scroll");
+}
 
 window.history.back();
 

--- a/src/Webapi/Dom/Webapi__Dom__History.res
+++ b/src/Webapi/Dom/Webapi__Dom__History.res
@@ -1,13 +1,17 @@
 type t = Dom.history
-type state /* TODO: should be "anything that can be serializable" apparently */
+
+@ocaml.doc("State could be anything that is serializable, to use this convert manually using %identity externals")
+type state
 
 @get external length: t => int = "length"
-@get external scrollRestoration: t => bool = "scrollRestoration" /* experimental */
-@set external setScrollRestoration: (t, bool) => unit = "scrollRestoration" /* experimental */
-@get external state: t => state = "state"
+@get external scrollRestoration: t => [#auto | #manual] = "scrollRestoration"
+@set external setScrollRestoration: (t, [#auto | #manual]) => unit = "scrollRestoration"
 
 @send external back: t => unit = "back"
 @send external forward: t => unit = "forward"
 @send external go: (t, int) => unit = "go"
+
+/** To add a popstate listener, use Window.addPopStateEventListener */
+@get external state: t => state = "state"
 @send external pushState: (t, state, string, string) => unit = "pushState"
 @send external replaceState: (t, state, string, string) => unit = "replaceState"

--- a/src/Webapi/Dom/Webapi__Dom__PopStateEvent.res
+++ b/src/Webapi/Dom/Webapi__Dom__PopStateEvent.res
@@ -7,4 +7,4 @@ include Webapi__Dom__Event.Impl({
 @new external make: string => t = "PopStateEvent"
 @new external makeWithOptions: (string, {..}) => t = "PopStateEvent"
 
-@get external state: t => {..} = "state"
+@get external state: t => Webapi__Dom__History.state = "state"

--- a/tests/Webapi/Dom/Webapi__Dom__History__test.res
+++ b/tests/Webapi/Dom/Webapi__Dom__History__test.res
@@ -3,8 +3,14 @@ open History
 
 let _ = history->length
 let _ = history->scrollRestoration
-let _ = history->setScrollRestoration(true)
+let _ = history->setScrollRestoration(#auto)
+let _ = history->setScrollRestoration(#manual)
 let _ = history->state
+
+switch (history->scrollRestoration) {
+  | #auto => Js.log("auto scroll")
+  | #manual => Js.log("manual scroll")
+}
 
 history->back
 history->forward


### PR DESCRIPTION
Fixes #86.

Added tests for get as well as set scroll restoration.
Tweaked some types and documentation to make it more obvious how to use the state API.