### PR TITLE
Convert Navigator types to records

### DIFF
--- a/src/Webapi/Dom/Webapi__Dom__RectList.res
+++ b/src/Webapi/Dom/Webapi__Dom__RectList.res
@@ -1,4 +1,4 @@
-type t = {
+type t = private {
   length: int
 }
 

--- a/src/Webapi/Fetch/Webapi__Fetch__AbortController.res
+++ b/src/Webapi/Fetch/Webapi__Fetch__AbortController.res
@@ -1,5 +1,5 @@
 type signal
-type t = {signal: signal}
+type t = private {signal: signal}
 
 @new external make: unit => t = "AbortController"
 @send external abort: t => unit = "abort"

--- a/src/Webapi/Webapi__FileList.res
+++ b/src/Webapi/Webapi__FileList.res
@@ -1,4 +1,4 @@
-type t = {
+type t = private {
   length: int
 }
 

--- a/src/Webapi/Webapi__Navigator.res
+++ b/src/Webapi/Webapi__Navigator.res
@@ -19,7 +19,7 @@ type t = private {
   /* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatorplugins */
   pdfViewerEnabled: bool,
   /* Spec: https://html.spec.whatwg.org/multipage/workers.html#navigatorconcurrenthardware */
-  hardwareConcurrency: float,
+  hardwareConcurrency: int,
 }
 
 /* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatorcontentutils */

--- a/src/Webapi/Webapi__Navigator.res
+++ b/src/Webapi/Webapi__Navigator.res
@@ -1,4 +1,4 @@
-type t = {
+type t = private {
   /* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatorid */
   userAgent: string,
   vendor: string,

--- a/src/Webapi/Webapi__Navigator.res
+++ b/src/Webapi/Webapi__Navigator.res
@@ -1,25 +1,26 @@
-type t
-
-/* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatorid */
-
-@get external userAgent: t => string = "userAgent"
-@get external vendor: t => string = "vendor"
-
-/* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatorlanguage */
-
-/**
- * Returns a BCP 47 language tag
- */
-@get external language: t => string = "language"
-
-/**
- * Experimental. Returns a readonly array of BCP 47 language tags
- */
-@get external languages: t => array<string> = "languages"
-
-/* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatoronline */
-
-@get external onLine: t => bool = "onLine"
+type t = {
+  /* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatorid */
+  userAgent: string,
+  vendor: string,
+  /**
+   * Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatorlanguage
+   *
+   * Returns a BCP 47 language tag
+   */
+  language: string,
+  /**
+   * Experimental. Returns a readonly array of BCP 47 language tags
+   */
+  languages: array<string>,
+  /* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatoronline */
+  onLine: bool,
+  /* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatorcookies */
+  cookieEnabled: bool,
+  /* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatorplugins */
+  pdfViewerEnabled: bool,
+  /* Spec: https://html.spec.whatwg.org/multipage/workers.html#navigatorconcurrenthardware */
+  hardwareConcurrency: float,
+}
 
 /* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatorcontentutils */
 
@@ -30,16 +31,3 @@ external registerProtocolHandler: (t, ~scheme: string, ~url: string) => unit =
 @send
 external unregisterProtocolHandler: (t, ~scheme: string, ~url: string) => unit =
   "unregisterProtocolHandler"
-
-/* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatorcookies */
-
-@get
-external cookieEnabled: t => bool = "cookieEnabled"
-
-/* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatorplugins */
-
-@get external pdfViewerEnabled: t => bool = "pdfViewerEnabled"
-
-/* Spec: https://html.spec.whatwg.org/multipage/workers.html#navigatorconcurrenthardware */
-
-@get external hardwareConcurrency: t => float = "hardwareConcurrency"

--- a/src/Webapi/Webapi__WorkerNavigator.res
+++ b/src/Webapi/Webapi__WorkerNavigator.res
@@ -1,29 +1,22 @@
 /**
  * Spec: https://html.spec.whatwg.org/multipage/workers.html#workernavigator
  */
-type t
-
-/* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatorid */
-
-@get external userAgent: t => string = "userAgent"
-@get external vendor: t => string = "vendor"
-
-/* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatorlanguage */
-
-/**
- * Returns a BCP 47 language tag
- */
-@get external language: t => string = "language"
-
-/**
- * Experimental. Returns a readonly array of BCP 47 language tags
- */
-@get external languages: t => array<string> = "languages"
-
-/* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatoronline */
-
-@get external onLine: t => bool = "onLine"
-
-/* Spec: https://html.spec.whatwg.org/multipage/workers.html#navigatorconcurrenthardware */
-
-@get external hardwareConcurrency: t => float = "hardwareConcurrency"
+type t = {
+  /* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatorid */
+  userAgent: string,
+  vendor: string,
+  /**
+   * Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatorlanguage
+   *
+   * Returns a BCP 47 language tag
+   */
+  language: string,
+  /**
+   * Experimental. Returns a readonly array of BCP 47 language tags
+   */
+  languages: array<string>,
+  /* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatoronline */
+  onLine: bool,
+  /* Spec: https://html.spec.whatwg.org/multipage/workers.html#navigatorconcurrenthardware */
+  hardwareConcurrency: float,
+}

--- a/src/Webapi/Webapi__WorkerNavigator.res
+++ b/src/Webapi/Webapi__WorkerNavigator.res
@@ -1,7 +1,7 @@
 /**
  * Spec: https://html.spec.whatwg.org/multipage/workers.html#workernavigator
  */
-type t = {
+type t = private {
   /* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatorid */
   userAgent: string,
   vendor: string,

--- a/src/Webapi/Webapi__WorkerNavigator.res
+++ b/src/Webapi/Webapi__WorkerNavigator.res
@@ -18,5 +18,5 @@ type t = private {
   /* Spec: https://html.spec.whatwg.org/multipage/system-state.html#navigatoronline */
   onLine: bool,
   /* Spec: https://html.spec.whatwg.org/multipage/workers.html#navigatorconcurrenthardware */
-  hardwareConcurrency: float,
+  hardwareConcurrency: int,
 }

--- a/tests/Webapi/Webapi__Navigator__test.res
+++ b/tests/Webapi/Webapi__Navigator__test.res
@@ -2,15 +2,15 @@ open Webapi.Dom
 
 let navigatorCopy = window->Window.navigator
 
-let userAgent = navigatorCopy->Webapi.Navigator.userAgent
-let vendor = navigatorCopy->Webapi.Navigator.vendor
-let language = navigatorCopy->Webapi.Navigator.language
-let languages = navigatorCopy->Webapi.Navigator.languages
-let onLine = navigatorCopy->Webapi.Navigator.onLine
-let hardwareConcurrency = navigatorCopy->Webapi.Navigator.hardwareConcurrency
+let userAgent = navigatorCopy.userAgent
+let vendor = navigatorCopy.vendor
+let language = navigatorCopy.language
+let languages = navigatorCopy.languages
+let onLine = navigatorCopy.onLine
+let hardwareConcurrency = navigatorCopy.hardwareConcurrency
 
 Webapi.Navigator.registerProtocolHandler(navigatorCopy, ~scheme="web+foo", ~url="foo?url=%s")
 Webapi.Navigator.unregisterProtocolHandler(navigatorCopy, ~scheme="web+foo", ~url="foo?url=%s")
 
-let cookieEnabled = navigatorCopy->Webapi.Navigator.cookieEnabled
-let pdfViewerEnabled = navigatorCopy->Webapi.Navigator.pdfViewerEnabled
+let cookieEnabled = navigatorCopy.cookieEnabled
+let pdfViewerEnabled = navigatorCopy.pdfViewerEnabled

--- a/tests/Webapi/Webapi__Navigator__test.res
+++ b/tests/Webapi/Webapi__Navigator__test.res
@@ -1,16 +1,16 @@
 open Webapi.Dom
 
-let navigatorCopy = window->Window.navigator
+let navigatorCopy: Webapi.Navigator.t = window->Window.navigator
 
-let userAgent = navigatorCopy.userAgent
-let vendor = navigatorCopy.vendor
-let language = navigatorCopy.language
-let languages = navigatorCopy.languages
-let onLine = navigatorCopy.onLine
-let hardwareConcurrency = navigatorCopy.hardwareConcurrency
+let userAgent: string = navigatorCopy.userAgent
+let vendor: string = navigatorCopy.vendor
+let language: string = navigatorCopy.language
+let languages: array<string> = navigatorCopy.languages
+let onLine: bool = navigatorCopy.onLine
+let hardwareConcurrency: int = navigatorCopy.hardwareConcurrency
 
 Webapi.Navigator.registerProtocolHandler(navigatorCopy, ~scheme="web+foo", ~url="foo?url=%s")
 Webapi.Navigator.unregisterProtocolHandler(navigatorCopy, ~scheme="web+foo", ~url="foo?url=%s")
 
-let cookieEnabled = navigatorCopy.cookieEnabled
-let pdfViewerEnabled = navigatorCopy.pdfViewerEnabled
+let cookieEnabled: bool = navigatorCopy.cookieEnabled
+let pdfViewerEnabled: bool = navigatorCopy.pdfViewerEnabled

--- a/tests/Webapi/Webapi__WorkerGlobalScope__test.res
+++ b/tests/Webapi/Webapi__WorkerGlobalScope__test.res
@@ -1,15 +1,15 @@
 open Webapi.WorkerGlobalScope
 
-let locationCopy = self->location
-let navigatorCopy = self->navigator
+let locationCopy: workerLocation = self->location
+let navigatorCopy: Webapi.WorkerNavigator.t = self->navigator
 
 self->setOnoffline((_event) => ())
-let onOffline = onoffline(self)
+let onOffline: eventHandler<Webapi.Dom.Event.t> = onoffline(self)
 importScripts(["module1", "module2"])
 
-let userAgent = navigatorCopy.userAgent
-let vendor = navigatorCopy.vendor
-let language = navigatorCopy.language
-let languages = navigatorCopy.languages
-let onLine = navigatorCopy.onLine
-let hardwareConcurrency = navigatorCopy.hardwareConcurrency
+let userAgent: string = navigatorCopy.userAgent
+let vendor: string = navigatorCopy.vendor
+let language: string = navigatorCopy.language
+let languages: array<string> = navigatorCopy.languages
+let onLine: bool = navigatorCopy.onLine
+let hardwareConcurrency: int = navigatorCopy.hardwareConcurrency

--- a/tests/Webapi/Webapi__WorkerGlobalScope__test.res
+++ b/tests/Webapi/Webapi__WorkerGlobalScope__test.res
@@ -7,9 +7,9 @@ self->setOnoffline((_event) => ())
 let onOffline = onoffline(self)
 importScripts(["module1", "module2"])
 
-let userAgent = navigatorCopy->Webapi.WorkerNavigator.userAgent
-let vendor = navigatorCopy->Webapi.WorkerNavigator.vendor
-let language = navigatorCopy->Webapi.WorkerNavigator.language
-let languages = navigatorCopy->Webapi.WorkerNavigator.languages
-let onLine = navigatorCopy->Webapi.WorkerNavigator.onLine
-let hardwareConcurrency = navigatorCopy->Webapi.WorkerNavigator.hardwareConcurrency
+let userAgent = navigatorCopy.userAgent
+let vendor = navigatorCopy.vendor
+let language = navigatorCopy.language
+let languages = navigatorCopy.languages
+let onLine = navigatorCopy.onLine
+let hardwareConcurrency = navigatorCopy.hardwareConcurrency


### PR DESCRIPTION
As discussed with @illusionalsagacity, who contributed the types in #57, this makes `navigator` significantly easier to use.

The tests prove there is no change to the generated JS as a result of this.