### PR TITLE
Add binding of createObjectURL that takes a Blob.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * `InputEvent` bindings for `inputType`, `dataTransfer` and `getTargetRanges` (#90)
 * `Node.insertAtEnd` binding (which does `parent.insertBefore(child, null)`) (#89)
 * CustomEvent Functor to make custom events with strongly typed `detail` fields (#93)
+* `Webapi.Url.createObjectURLFromBlob` binding that takes a `Webapi.Blob.t` (#106)
 
 ### Fixed
 * `ofElement` was incorrectly returning `Dom.htmlElement` type instead of the enclosing element type (#60)

--- a/src/Webapi/Webapi__Url.res
+++ b/src/Webapi/Webapi__Url.res
@@ -49,4 +49,5 @@ type t
 @get external toJson: t => string = "toJson"
 
 @val @scope("URL") external createObjectURL: Webapi__File.t => string = "createObjectURL"
+@val @scope("URL") external createObjectURLFromBlob: Webapi__Blob.t => string = "createObjectURL"
 @val @scope("URL") external revokeObjectURL: string => unit = "revokeObjectURL"


### PR DESCRIPTION
The function 'URL.createObjectURL' can take File, Blob and MediaSource.  This PR simply adds a binding for Blob.