### PR TITLE
Use correct name for setProperty

### DIFF
--- a/src/Webapi/Dom/Webapi__Dom__CssStyleDeclaration.res
+++ b/src/Webapi/Dom/Webapi__Dom__CssStyleDeclaration.res
@@ -11,7 +11,7 @@ type cssRule /* TODO: Move to Webapi__Dom */
 @send external item: (t, int) => string = "item"
 @send external removeProperty: (t, string) => string = "removeProperty"
 @send external setProperty: (t, string, string, string) => unit = "setProperty"
-@send external setPropertyValue: (t, string, string) => unit = "setPropertyValue"
+@send external setPropertyValue: (t, string, string) => unit = "setProperty"
 
 /* CSS2Properties */
 @get external azimuth: t => string = "azimuth"


### PR DESCRIPTION
I'm not certain this is right, as I'm not as familiar with the current incarnation of Rescripts externals.

My read of this code is that `setProperty` is intended to call
[setProperty](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/setProperty) with 2 arguments, and `setPropertyValue` is supposed to call `setProperty` with 3 arguments.

There are related functions `getProperty` and `getPropertyValue`, but there isn't a `setPropertyValue`, so my guess is there was a typo here.